### PR TITLE
Specify getFilterKey to avoid "TypeError: string.indexOf is not a function"

### DIFF
--- a/lib/project-path-list-view.coffee
+++ b/lib/project-path-list-view.coffee
@@ -22,6 +22,8 @@ module.exports =
       $$ ->
         @li path
 
+    getFilterKey: -> 'path'
+
     confirmed: ({path}) ->
       require('./open-sourcetree')(path)
       @cancel()


### PR DESCRIPTION
I also stumbled across https://github.com/cliffrowley/atom-open-in-sourcetree/issues/12 and was able to fix it. The problem that the instance of `SelectListView` did not know what key to use when filtering projects during search.

See https://github.com/atom/atom-space-pen-views#getfilterquery