### PR TITLE
Fix to point to SourceTree location in Windows

### DIFF
--- a/lib/open-sourcetree.coffee
+++ b/lib/open-sourcetree.coffee
@@ -6,13 +6,25 @@ openOnMac = (projectPath) ->
   appBundleIndentifier = 'com.torusknot.SourceTreeNotMAS'
   spawn '/usr/bin/open', ['-b', appBundleIndentifier, projectPath]
 
+openOnLinux = (projectPath) ->
+  atom.notifications.addInfo 'Open in SourceTree',
+    detail: 'No Sourcetree on Linux yet'
+
 openOnWindows = (projectPath) ->
-  exec "cd \"#{projectPath}\" & " +
-       "\"C:\\Program Files (x86)\\Atlassian\\SourceTree\\SourceTree.exe\""
+  execpath = "\"%LOCALAPPDATA%\\SourceTree\\SourceTree.exe\" -f \"#{projectPath}\""
+
+  # Add notification
+  atom.notifications.addInfo 'Open in SourceTree',
+    detail: execpath
+
+  exec execpath
+  # exec "cd \"#{projectPath}\" & " +
+  # "\"C:\\Program Files (x86)\\Atlassian\\SourceTree\\SourceTree.exe\""
 
 openAppForDirectory = (projectPath) ->
   switch process.platform
     when 'darwin' then openOnMac(projectPath)
     when 'win32'  then openOnWindows(projectPath)
+    when 'linux'  then openOnLinux(projectPath)
 
 module.exports = openAppForDirectory


### PR DESCRIPTION
Fixes #13 by updating the relevant path for SourceTree

Also, adds Linux exception